### PR TITLE
updated/fixed a misleading description

### DIFF
--- a/Lab-00/00-tech-lab-2.adoc
+++ b/Lab-00/00-tech-lab-2.adoc
@@ -114,7 +114,7 @@ image::eml-w-code.png[]
 
 (Do NOT use the code in the image above. Use the code you got in your email.)
 
-Go to http://cloud.google.com now and enter your code:
+Click the link "[here]" under the code, then you will see the following page:
 
 
 image::GCP-accept.png[]


### PR DESCRIPTION
I went to the http://cloud.google.com, and didn't find any button/link that can let me jump to Education Grants Page. So we actually need to click the link that come from the redeem code email. 